### PR TITLE
Use ED-25519 host key for github.com

### DIFF
--- a/dist/profile/manifests/buildagent.pp
+++ b/dist/profile/manifests/buildagent.pp
@@ -108,8 +108,8 @@ class profile::buildagent (
   sshkey { 'github-rsa':
     ensure       => present,
     host_aliases => ['github.com'],
-    type         => 'ssh-rsa',
-    key          => 'AAAAB3NzaC1yc2EAAAADAQABAAABgQCj7ndNxQowgcQnjshcLrqPEiiphnt+VTTvDP6mHBL9j1aNUkY4Ue1gvwnGLVlOhGeYrnZaMgRK6+PKCUXaDbC7qtbW8gIkhL7aGCsOr/C56SJMy/BCZfxd1nWzAOxSDPgVsmerOBYfNqltV9/hWCqBywINIR+5dIg6JTJ72pcEpEjcYgXkE2YEFXV1JHnsKgbLWNlhScqb2UmyRkQyytRLtL+38TGxkxCflmO+5Z8CSSNY7GidjMIZ7Q4zMjA2n1nGrlTDkzwDCsw+wqFPGQA179cnfGWOWRVruj16z6XyvxvjJwbz0wQZ75XK5tKSb7FNyeIEs4TT4jk+S4dhPeAUC5y+bDYirYgM4GC7uEnztnZyaVWQ7B381AK4Qdrwt51ZqExKbQpTUNn+EjqoTwvqNj4kqx5QUCI0ThS/YkOxJCXmPUWZbhjpCg56i+2aB6CmK2JGhn57K5mj0MNdBXA4/WnwH6XoPWJzK5Nyu2zB3nAZp+S5hpQs+p1vN1/wsjk=',
+    type         => 'ssh-ed25519',
+    key          => 'AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl',
   }
 
   sshkey { 'github-dsa':


### PR DESCRIPTION
The ED-25519 host key is a shorter string and was not rotated by GitHub in their 2023-03-24 host key rotation.  It was not rotated because the ED-25519 private host key was not exposed in a public repository like the RSA private host key was.

Consider this a prototype for discussion of the idea of switching to use ED-25519 rather than as a firm claim that this is what we should do.

The Jenkins git client plugin documentation includes the ED-25519 host key for github.com in its configuration as code sample because it is much easier to read that string and it is at least as strong as the RSA key.

See https://news.ycombinator.com/item?id=12575358 for more details describing why ED-25519 keys are better than RSA keys.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
